### PR TITLE
Update helm-qa to include latest kubernetes versions

### DIFF
--- a/.github/workflows/helm-qa.yml
+++ b/.github/workflows/helm-qa.yml
@@ -75,6 +75,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s:
+          - v1.32.0
+          - v1.31.0
           - v1.29.0
           - v1.28.0
           - v1.27.0
@@ -156,6 +158,9 @@ jobs:
       fail-fast: false
       matrix:
         k8s:
+          - v1.32.0
+          - v1.31.0
+          - v1.30.0
           - v1.29.0
           - v1.28.0
           - v1.27.0

--- a/test-content/helm-qa/test/charts/wireguard/README.md
+++ b/test-content/helm-qa/test/charts/wireguard/README.md
@@ -14,7 +14,7 @@ A Helm chart for managing a wireguard vpn in kubernetes
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"app":"{{ .Release.Name }}-wireguard","role":"vpn"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Set pod affinity or antiAffinity |
+| affinity | object | `{"podAntiAffinity":null}` | Set pod affinity or antiAffinity |
 | autoscaling.enabled | bool | `true` |  |
 | autoscaling.maxReplicas | int | `10` |  |
 | autoscaling.minReplicas | int | `3` |  |

--- a/test-content/helm-qa/test/charts/wireguard/values.yaml
+++ b/test-content/helm-qa/test/charts/wireguard/values.yaml
@@ -140,13 +140,7 @@ affinity:
   #     - matchExpressions:
   #       - key: "example.com/vpn"
   #         operator: Exists
-  podAntiAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchLabels:
-            app: "{{ .Release.Name }}-wireguard"
-            role: vpn
-        topologyKey: kubernetes.io/hostname
+  podAntiAffinity: ~
 # -- Set pod nodeSelector, a simplified version of affinity
 nodeSelector: {}
   # example.com/vpn: ""


### PR DESCRIPTION
Adds coverage for testing up to and included in kubernetes 1.32 in flows using the helm-qa flow.